### PR TITLE
DOC stays connected to the call globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import { useCallCountWithStatus, useCallsWithStatus } from "./hooks/useCalls";
 import Modals from "./components/Modals";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
+import { LiveCallsContext } from "./context/LiveCallsContext";
+import { useLiveCalls } from "./hooks/useLiveCalls";
 
 const LOGIN_PATH = "/login";
 
@@ -110,6 +112,8 @@ function App({ history }: { history: History }) {
     }
   }, [selected, dispatch]);
 
+  const liveCallsContextValue = useLiveCalls();
+
   return (
     <ConnectedRouter history={history}>
       <Layout style={{ minHeight: "100vh" }}>
@@ -133,18 +137,20 @@ function App({ history }: { history: History }) {
           session.status === "loading" ? (
             <Loader />
           ) : (
-            <Switch>
-              <Route exact path={LOGIN_PATH} component={Login}></Route>
-              {ROUTES.map((route) => (
-                <ProtectedRoute
-                  exact
-                  {...defaultProtectedRouteProps}
-                  path={route.path}
-                  component={route.component}
-                  key={route.label}
-                ></ProtectedRoute>
-              ))}
-            </Switch>
+            <LiveCallsContext.Provider value={liveCallsContextValue}>
+              <Switch>
+                <Route exact path={LOGIN_PATH} component={Login}></Route>
+                {ROUTES.map((route) => (
+                  <ProtectedRoute
+                    exact
+                    {...defaultProtectedRouteProps}
+                    path={route.path}
+                    component={route.component}
+                    key={route.label}
+                  ></ProtectedRoute>
+                ))}
+              </Switch>
+            </LiveCallsContext.Provider>
           )}
         </Layout>
       </Layout>

--- a/src/context/LiveCallsContext.tsx
+++ b/src/context/LiveCallsContext.tsx
@@ -6,14 +6,12 @@ export interface LiveCallsContextData {
   roomClients: Record<string, RoomClient>;
   remoteVideos: Record<string, Record<StreamId, MediaStream>>;
   remoteAudios: Record<string, Record<StreamId, MediaStream>>;
-  // joinRoom: (callId: string, socket: SocketIOClient.Socket) => void;
 }
 
 export const liveCallsContextDefaultValue: LiveCallsContextData = {
   roomClients: {},
   remoteVideos: {},
   remoteAudios: {},
-  // joinRoom: () => null,
 };
 
 export const LiveCallsContext = createContext<LiveCallsContextData>(

--- a/src/context/LiveCallsContext.tsx
+++ b/src/context/LiveCallsContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+import RoomClient from "src/pages/LiveCall/RoomClient";
+
+export interface LiveCallsContextData {
+  roomClients: Record<string, RoomClient>;
+  // joinRoom: (callId: string, socket: SocketIOClient.Socket) => void;
+}
+
+export const liveCallsContextDefaultValue: LiveCallsContextData = {
+  roomClients: {},
+  // joinRoom: () => null,
+};
+
+export const LiveCallsContext = createContext<LiveCallsContextData>(
+  liveCallsContextDefaultValue
+);

--- a/src/context/LiveCallsContext.tsx
+++ b/src/context/LiveCallsContext.tsx
@@ -1,13 +1,18 @@
 import { createContext } from "react";
 import RoomClient from "src/pages/LiveCall/RoomClient";
+import { StreamId } from "src/typings/Common";
 
 export interface LiveCallsContextData {
   roomClients: Record<string, RoomClient>;
+  remoteVideos: Record<string, Record<StreamId, MediaStream>>;
+  remoteAudios: Record<string, Record<StreamId, MediaStream>>;
   // joinRoom: (callId: string, socket: SocketIOClient.Socket) => void;
 }
 
 export const liveCallsContextDefaultValue: LiveCallsContextData = {
   roomClients: {},
+  remoteVideos: {},
+  remoteAudios: {},
   // joinRoom: () => null,
 };
 

--- a/src/hooks/useLiveCalls.ts
+++ b/src/hooks/useLiveCalls.ts
@@ -2,13 +2,18 @@ import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { LiveCallsContextData } from "src/context/LiveCallsContext";
 import RoomClient from "src/pages/LiveCall/RoomClient";
-import { RootState } from "src/redux";
-import { Call } from "src/typings/Call";
-import { getVideoHandlerHostname } from "src/utils";
+import { RootState, useAppDispatch } from "src/redux";
+import { Call, CallParticipant, InCallStatus } from "src/typings/Call";
+import { getParticipantStreamId, getVideoHandlerHostname } from "src/utils";
 import { useCallsWithStatus } from "./useCalls";
 import io from "socket.io-client";
+import { StreamId } from "src/typings/Common";
+import { callsActions } from "src/redux/modules/call";
+
+type CallId = string;
 
 export function useLiveCalls(): LiveCallsContextData {
+  // TODO: this was helpful when there were
   const [socketMap, setSocketMap] = useState<
     Record<string, SocketIOClient.Socket>
   >({});
@@ -16,6 +21,16 @@ export function useLiveCalls(): LiveCallsContextData {
   const [roomClients, setRoomClients] = useState<Record<string, RoomClient>>(
     {}
   );
+
+  const [remoteVideos, setRemoteVideos] = useState<
+    Record<CallId, Record<StreamId, MediaStream>>
+  >({});
+
+  const [remoteAudios, setRemoteAudios] = useState<
+    Record<CallId, Record<StreamId, MediaStream>>
+  >({});
+
+  const dispatch = useAppDispatch();
 
   const visitations = useCallsWithStatus("live");
 
@@ -33,6 +48,101 @@ export function useLiveCalls(): LiveCallsContextData {
     setFreshCalls(newCalls);
   }, [socketMap, visitations]);
 
+  const initRc = useCallback(
+    async (rc: RoomClient, callId: string) => {
+      console.log(`[initRc] Initializing room client for ${callId}`);
+      await rc.init();
+
+      // consume events
+      rc.on(
+        "consume",
+        async (
+          kind: string,
+          stream: MediaStream,
+          participant: CallParticipant
+        ) => {
+          console.log(
+            `[VideoChat] Received ${kind} consume from ${participant.type} ${participant.id}`
+          );
+          if (kind === "video") {
+            setRemoteVideos((remotes) => ({
+              ...remotes,
+              [callId]: {
+                ...remotes[callId],
+                [getParticipantStreamId(participant, callId)]: stream,
+              },
+            }));
+          } else if (kind === "audio") {
+            setRemoteAudios((remotes) => ({
+              ...remotes,
+              [callId]: {
+                ...remotes[callId],
+                [getParticipantStreamId(participant, callId)]: stream,
+              },
+            }));
+          }
+        }
+      );
+
+      // disconnect event
+      rc.socket.on(
+        "participantDisconnect",
+        // TODO unpack this appropriately
+        async (participant: CallParticipant) => {
+          console.log("[Disconnect] Participant disconnect", participant);
+          setRemoteVideos((remotes) => {
+            const { [callId]: streams, ...otherRemotes } = remotes;
+
+            const {
+              [getParticipantStreamId(participant, callId)]: _,
+              ...otherStreams
+            } = streams;
+
+            return { ...otherRemotes, [callId]: otherStreams };
+          });
+          setRemoteAudios((remotes) => {
+            const { [callId]: streams, ...otherRemotes } = remotes;
+
+            const {
+              [getParticipantStreamId(participant, callId)]: _,
+              ...otherStreams
+            } = streams;
+
+            return { ...otherRemotes, [callId]: otherStreams };
+          });
+        }
+      );
+
+      // listening for text messages
+      rc.socket.on("callStatus", async (status: InCallStatus) => {
+        console.log("[VideoChat] Received status update", status);
+        // TODO: check this works
+        if (status === "terminated" || status === "ended") {
+          rc.destroy();
+        }
+      });
+
+      // listening to text messages
+      rc.socket.on(
+        "textMessage",
+        ({ from, contents }: { from: CallParticipant; contents: string }) => {
+          console.log(
+            `[VideoChat] Received text message from ${from.type} for ${callId}`
+          );
+          const message = {
+            contents,
+            senderId: from.id,
+            senderType: from.type,
+            createdAt: new Date().toISOString(),
+            callId,
+          };
+          dispatch(callsActions.addMessage({ id: callId, message }));
+        }
+      );
+    },
+    [dispatch]
+  );
+
   const joinRoom = useCallback(
     async (callId: string, socket: SocketIOClient.Socket) => {
       if (!socket.connected) {
@@ -42,16 +152,19 @@ export function useLiveCalls(): LiveCallsContextData {
         console.log(`[VideoChat] Connected to call ${callId}`);
       }
 
+      console.log(`[VideoChat] Authenticating call ${callId}`);
       await new Promise((resolve) => {
         socket.emit("authenticate", authInfo, resolve);
       });
+      console.log(`[VideoChat] Authenticated for call ${callId}`);
 
       const rc = new RoomClient(socket, callId);
-      await rc.init();
-      console.log(`[VideoChat] Authenticated for call ${callId}`);
+      await initRc(rc, callId);
+      console.log(`[initRc] Done initializing room client for ${callId}`);
+
       setRoomClients((rcs) => ({ ...rcs, [callId]: rc }));
     },
-    [authInfo]
+    [authInfo, initRc]
   );
 
   // only establish new socket connections with fresh calls
@@ -70,7 +183,7 @@ export function useLiveCalls(): LiveCallsContextData {
       temp[target] = newSocketClient;
       joinRoom(call.id, newSocketClient);
     }
-    console.log("[Index] New socket clients", temp);
+    console.log("[Fresh calls] New socket clients", temp);
     setSocketMap((curr) => ({ ...curr, ...temp }));
   }, [freshCalls, joinRoom]);
 
@@ -83,7 +196,18 @@ export function useLiveCalls(): LiveCallsContextData {
     return () => clearInterval(interval);
   }, [roomClients]);
 
+  // useEffect(() => {
+  //   return () => {
+  //     for (const rc of Object.values(roomClients)) {
+  //       console.log("[Cleanup] Destroying room clients");
+  //       rc.destroy();
+  //     }
+  //   };
+  // }, [roomClients]);
+
   return {
     roomClients,
+    remoteVideos,
+    remoteAudios,
   };
 }

--- a/src/hooks/useLiveCalls.ts
+++ b/src/hooks/useLiveCalls.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { LiveCallsContextData } from "src/context/LiveCallsContext";
+import RoomClient from "src/pages/LiveCall/RoomClient";
+import { RootState } from "src/redux";
+import { Call } from "src/typings/Call";
+import { getVideoHandlerHostname } from "src/utils";
+import { useCallsWithStatus } from "./useCalls";
+import io from "socket.io-client";
+
+export function useLiveCalls(): LiveCallsContextData {
+  const [socketMap, setSocketMap] = useState<
+    Record<string, SocketIOClient.Socket>
+  >({});
+
+  const [roomClients, setRoomClients] = useState<Record<string, RoomClient>>(
+    {}
+  );
+
+  const visitations = useCallsWithStatus("live");
+
+  const authInfo = useSelector((state: RootState) => state.session.authInfo);
+
+  const [freshCalls, setFreshCalls] = useState<Call[]>([]);
+
+  //  check for new calls
+  useEffect(() => {
+    const newCalls = visitations.filter(
+      (call) =>
+        call.videoHandler &&
+        !(getVideoHandlerHostname(call.videoHandler) in socketMap)
+    );
+    setFreshCalls(newCalls);
+  }, [socketMap, visitations]);
+
+  const joinRoom = useCallback(
+    async (callId: string, socket: SocketIOClient.Socket) => {
+      if (!socket.connected) {
+        console.log("Not connected, so waiting until connected.");
+        window.Debug = socket;
+        await new Promise((resolve) => socket.on("connect", resolve));
+        console.log(`[VideoChat] Connected to call ${callId}`);
+      }
+
+      await new Promise((resolve) => {
+        socket.emit("authenticate", authInfo, resolve);
+      });
+
+      const rc = new RoomClient(socket, callId);
+      await rc.init();
+      console.log(`[VideoChat] Authenticated for call ${callId}`);
+      setRoomClients((rcs) => ({ ...rcs, [callId]: rc }));
+    },
+    [authInfo]
+  );
+
+  // only establish new socket connections with fresh calls
+  useEffect(() => {
+    if (!freshCalls.length) return;
+
+    const temp: Record<string, SocketIOClient.Socket> = {};
+
+    for (const call of freshCalls) {
+      if (!call.videoHandler) continue;
+      const target = getVideoHandlerHostname(call.videoHandler);
+      // initialize new sockets once
+      if (target in temp) continue;
+
+      const newSocketClient = io.connect(target, { transports: ["websocket"] });
+      temp[target] = newSocketClient;
+      joinRoom(call.id, newSocketClient);
+    }
+    console.log("[Index] New socket clients", temp);
+    setSocketMap((curr) => ({ ...curr, ...temp }));
+  }, [freshCalls, joinRoom]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      for (const [callId, rc] of Object.entries(roomClients)) {
+        rc.socket.emit("heartbeat", { callId });
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [roomClients]);
+
+  return {
+    roomClients,
+  };
+}

--- a/src/hooks/useLiveCalls.ts
+++ b/src/hooks/useLiveCalls.ts
@@ -13,7 +13,8 @@ import { callsActions } from "src/redux/modules/call";
 type CallId = string;
 
 export function useLiveCalls(): LiveCallsContextData {
-  // TODO: this was helpful when there were
+  // TODO: this was helpful when there were multiple calls in a roomm
+  // might want to remove this now that it's not the case
   const [socketMap, setSocketMap] = useState<
     Record<string, SocketIOClient.Socket>
   >({});
@@ -87,7 +88,6 @@ export function useLiveCalls(): LiveCallsContextData {
       // disconnect event
       rc.socket.on(
         "participantDisconnect",
-        // TODO unpack this appropriately
         async (participant: CallParticipant) => {
           console.log("[Disconnect] Participant disconnect", participant);
           setRemoteVideos((remotes) => {

--- a/src/pages/LiveCall/RoomClient.ts
+++ b/src/pages/LiveCall/RoomClient.ts
@@ -168,6 +168,7 @@ class RoomClient {
 
   async terminate() {
     await this.request("terminate", { callId: this.callId });
+    await this.destroy();
   }
 
   async destroy() {

--- a/src/pages/LiveCall/VideoChat.tsx
+++ b/src/pages/LiveCall/VideoChat.tsx
@@ -35,7 +35,6 @@ interface Props {
   closeChat: (id: string) => void;
   chatCollapsed: boolean;
   lockCall: (id: string) => void;
-  // addMessage: (id: string, message: CallMessage) => void;
   rc: RoomClient;
   remoteVideos: Record<string, MediaStream>;
   remoteAudios: Record<string, MediaStream>;
@@ -70,7 +69,6 @@ const VideoChat: React.FC<Props> = React.memo(
     openChat,
     closeChat,
     chatCollapsed,
-    // addMessage,
     participantNames,
     rc,
     remoteVideos,

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -38,7 +38,7 @@ export const rootReducer = createRootReducer(history);
 export const Store = configureStore({
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(routerMiddleware(history)),
+    getDefaultMiddleware().concat([routerMiddleware(history)]),
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/redux/modules/facility.ts
+++ b/src/redux/modules/facility.ts
@@ -21,7 +21,7 @@ export const selectActiveFacility = createAsyncThunk(
   async (facility: Facility) => {
     // need to harcode the nodeId for initialization,
     const bodyCt = await fetchAuthenticated(
-      `facilities/${facility.id}/callSlots`,
+      `facilities/${facility.id}/visitSlots`,
       {},
       false
     );

--- a/src/typings/Common.ts
+++ b/src/typings/Common.ts
@@ -25,3 +25,5 @@ export interface RejectionReason {
   description: string;
   key: string;
 }
+
+export type StreamId = string;

--- a/src/utils/Call.ts
+++ b/src/utils/Call.ts
@@ -23,7 +23,7 @@ import { Dictionary } from "@reduxjs/toolkit";
 import { Inmate } from "src/typings/Inmate";
 import { notEmpty } from "./Common";
 import { Kiosk } from "src/typings/Kiosk";
-import { VisitationType } from "src/typings/Common";
+import { StreamId, VisitationType } from "src/typings/Common";
 
 const callSlotToDateString = (time: CallSlot): string => {
   const date = new Date();
@@ -302,12 +302,11 @@ export const getVideoHandlerHostname = (handler: CallVideoHandler) => {
   return `https://${handler.host}:${handler.port}`;
 };
 
-type StreamId = string;
-
 export const getParticipantStreamId = (
-  participant: CallParticipant
+  participant: CallParticipant,
+  callId: string
 ): StreamId => {
-  return `${participant.type}-${participant.id}`;
+  return `${callId}-${participant.type}-${participant.id}`;
 };
 
 export const getStreamParticipantType = (


### PR DESCRIPTION
## Motivation
- Before, DOC could not navigate to other tabs within Ameelio Connect w/o the calls dropping.
- The live calls page was very vulnerable to unmounts 


## Solution
Moving the room client and socket logic to a separate higher level hook that can be accessed by the React Context API.

Because the socket connections are only used on this one page, it didn't make sense to me to add it to the Redux store. Also Redux would be unhappy about storing the RoomClient class.

After doing some research on different approaches to web socket connection, I thought the Context API was modular and easy to implement.

